### PR TITLE
AI Improvements

### DIFF
--- a/src/main/java/net/emirikol/golemancy/entity/EntropicGolemEntity.java
+++ b/src/main/java/net/emirikol/golemancy/entity/EntropicGolemEntity.java
@@ -18,7 +18,7 @@ public class EntropicGolemEntity extends AbstractGolemEntity {
 	@Override 
 	protected void initGoals() {
 		super.initGoals();
-		this.goalSelector.add(6, new GolemMoveToBreakGoal(this, 10.0F, 3.0F));
+		this.goalSelector.add(6, new GolemMoveToBreakBlockGoal(this, 10.0F, 3.0F));
 	}
 	
 	@Override

--- a/src/main/java/net/emirikol/golemancy/entity/EntropicGolemEntity.java
+++ b/src/main/java/net/emirikol/golemancy/entity/EntropicGolemEntity.java
@@ -18,7 +18,7 @@ public class EntropicGolemEntity extends AbstractGolemEntity {
 	@Override 
 	protected void initGoals() {
 		super.initGoals();
-		this.goalSelector.add(6, new GolemMoveToBreakBlockGoal(this, 10.0F, 3.0F));
+		this.goalSelector.add(6, new GolemMoveToMineGoal(this, 10.0F, 3.0F));
 	}
 	
 	@Override

--- a/src/main/java/net/emirikol/golemancy/entity/goal/GolemMoveGoal.java
+++ b/src/main/java/net/emirikol/golemancy/entity/goal/GolemMoveGoal.java
@@ -43,8 +43,8 @@ public class GolemMoveGoal extends Goal {
 
 	@Override
 	public boolean shouldContinue() {
-		//Continue as long as targetPos is valid and 20 seconds have not elapsed.
-		return this.idleTime < 400 && this.isTargetPos(this.targetPos);
+		//Continue as long as targetPos is valid and less than 40 ticks of idling have occurred.
+		return this.idleTime < 40 && this.isTargetPos(this.targetPos);
 	}
 
 	@Override
@@ -57,14 +57,13 @@ public class GolemMoveGoal extends Goal {
 	public void tick() {
 		if (!this.targetPos.isWithinDistance(this.entity.getPos(), this.getDesiredDistanceToTarget())) {
 			//Continue towards targetPos.
-			this.idleTime++;
-			if (this.idleTime % 40 == 0) {
-				//Reset navigation after every 2 seconds of movement.
-				this.entity.getNavigation().startMovingTo(this.targetPos.getX(), this.targetPos.getY(), this.targetPos.getZ(), 1);
-			}
-			if (this.idleTime >= 400) {
-				//Give up on this target after 20 seconds have elapsed.
+			if (this.entity.getNavigation().isIdle()) this.idleTime++;
+
+			if (this.idleTime >= 40) {
+				//Give up after 40 ticks of idling, and add the targetPos to the list of failed targets.
 				this.failedTargets.add(this.targetPos);
+			} else {
+				this.entity.getNavigation().startMovingTo(this.targetPos.getX(), this.targetPos.getY(), this.targetPos.getZ(), 1);
 			}
 		}
 	}

--- a/src/main/java/net/emirikol/golemancy/entity/goal/GolemMoveGoal.java
+++ b/src/main/java/net/emirikol/golemancy/entity/goal/GolemMoveGoal.java
@@ -98,7 +98,7 @@ public class GolemMoveGoal extends Goal {
 	public boolean isTargetPos(BlockPos pos) {
 		//Used to determine whether a given BlockPos qualifies to be our targetPos.
 		//By default, just disallows any targetPos we have already tried and failed to reach.
-		return this.failedTargets.isEmpty() || !this.failedTargets.contains(pos);
+		return !this.failedTargets.contains(pos);
 	}
 
 	public boolean canReachPos(BlockPos pos) {

--- a/src/main/java/net/emirikol/golemancy/entity/goal/GolemMoveToBreakBlockGoal.java
+++ b/src/main/java/net/emirikol/golemancy/entity/goal/GolemMoveToBreakBlockGoal.java
@@ -1,0 +1,26 @@
+package net.emirikol.golemancy.entity.goal;
+
+import net.emirikol.golemancy.entity.AbstractGolemEntity;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.util.math.BlockPos;
+
+public class GolemMoveToBreakBlockGoal extends GolemMoveToBreakGoal {
+
+    public GolemMoveToBreakBlockGoal(AbstractGolemEntity entity, float searchRadius, float maxYDifference) {
+        super(entity, searchRadius, maxYDifference);
+    }
+
+    @Override
+    public boolean isTargetPos(BlockPos pos) {
+        //Must match the Block type of the golem's linked block.
+        BlockState state = this.entity.world.getBlockState(pos);
+        if (state == null) { return false; }
+        Block linkedBlock = this.entity.getLinkedBlock();
+        if (linkedBlock == null) { return false; }
+
+        return (state.getBlock() == linkedBlock) && super.isTargetPos(pos);
+    }
+
+    protected int getMaxProgress() { return 120; }
+}

--- a/src/main/java/net/emirikol/golemancy/entity/goal/GolemMoveToBreakGoal.java
+++ b/src/main/java/net/emirikol/golemancy/entity/goal/GolemMoveToBreakGoal.java
@@ -78,6 +78,11 @@ public class GolemMoveToBreakGoal extends GolemMoveGoal {
 		return false;
 	}
 
+	@Override
+	public double getDesiredDistanceToTarget() {
+		return BREAK_RANGE;
+	}
+
 	public boolean isWithinBreakRange(BlockPos pos) {
 		//Check if a block is close enough to break.
 		return pos.isWithinDistance(this.entity.getPos(), BREAK_RANGE);

--- a/src/main/java/net/emirikol/golemancy/entity/goal/GolemMoveToBreakGoal.java
+++ b/src/main/java/net/emirikol/golemancy/entity/goal/GolemMoveToBreakGoal.java
@@ -10,16 +10,11 @@ import net.minecraft.util.math.*;
 
 import java.util.EnumSet;
 
-public class GolemMoveToBreakGoal extends GolemMoveGoal {
+public abstract class GolemMoveToBreakGoal extends GolemMoveGoal {
 	protected static final double BREAK_RANGE = 5.0D;
 
 	protected int breakProgress;
 	protected int prevBreakProgress;
-
-	public GolemMoveToBreakGoal(AbstractGolemEntity entity, float searchRadius) {
-		super(entity, searchRadius, 1);
-		this.setControls(EnumSet.of(Goal.Control.MOVE, Goal.Control.LOOK));
-	}
 	
 	public GolemMoveToBreakGoal(AbstractGolemEntity entity, float searchRadius, float maxYDifference) {
 		super(entity, searchRadius, maxYDifference);
@@ -59,13 +54,8 @@ public class GolemMoveToBreakGoal extends GolemMoveGoal {
 	
 	@Override
 	public boolean isTargetPos(BlockPos pos) {
-		//Must match the Block type of the golem's linked block.
-		BlockState state = this.entity.world.getBlockState(pos);
-		if (state == null) { return false; }
-		Block linkedBlock = this.entity.getLinkedBlock();
-		if (linkedBlock == null) { return false; }
-		
-		return (state.getBlock() == linkedBlock) && super.isTargetPos(pos);
+		//Override in subclasses to determine exactly what kinds of block are broken.
+		return super.isTargetPos(pos);
 	}
 
 	@Override
@@ -100,7 +90,5 @@ public class GolemMoveToBreakGoal extends GolemMoveGoal {
 		return this.entity.getBlockBreakHardnessFromStrength();
 	}
 
-	protected int getMaxProgress() {
-		return 120;
-	}
+	protected abstract int getMaxProgress();
 }

--- a/src/main/java/net/emirikol/golemancy/entity/goal/GolemMoveToFishGoal.java
+++ b/src/main/java/net/emirikol/golemancy/entity/goal/GolemMoveToFishGoal.java
@@ -63,6 +63,11 @@ public class GolemMoveToFishGoal extends GolemMoveGoal {
         return (fluidState.getFluid() == Fluids.WATER) && fluidState.isStill() && !fluidState.isEmpty() && super.isTargetPos(pos);
     }
 
+    @Override
+    public double getDesiredDistanceToTarget() {
+        return FISH_RANGE;
+    }
+
     public boolean hasRod() {
         ItemStack stack = this.entity.getEquippedStack(EquipmentSlot.MAINHAND);
         return stack.getItem() == Items.FISHING_ROD;

--- a/src/main/java/net/emirikol/golemancy/entity/goal/GolemMoveToFluidGoal.java
+++ b/src/main/java/net/emirikol/golemancy/entity/goal/GolemMoveToFluidGoal.java
@@ -10,10 +10,7 @@ import net.minecraft.server.world.*;
 import java.util.EnumSet;
 
 public class GolemMoveToFluidGoal extends GolemMoveGoal {
-	public GolemMoveToFluidGoal(AbstractGolemEntity entity, float searchRadius) {
-		super(entity, searchRadius, 1);
-		this.setControls(EnumSet.of(Goal.Control.MOVE, Goal.Control.LOOK));
-	}
+	private static final int FILL_RANGE = 3;
 	
 	public GolemMoveToFluidGoal(AbstractGolemEntity entity, float searchRadius, float maxYDifference) {
 		super(entity, searchRadius, maxYDifference);
@@ -41,5 +38,10 @@ public class GolemMoveToFluidGoal extends GolemMoveGoal {
 		ServerWorld world = (ServerWorld) this.entity.world;
 		FluidState fluidState = world.getBlockState(pos).getFluidState();
 		return fluidState.isStill() && !fluidState.isEmpty() && super.isTargetPos(pos);
+	}
+
+	@Override
+	public double getDesiredDistanceToTarget() {
+		return FILL_RANGE;
 	}
 }

--- a/src/main/java/net/emirikol/golemancy/entity/goal/GolemMoveToHarvestGoal.java
+++ b/src/main/java/net/emirikol/golemancy/entity/goal/GolemMoveToHarvestGoal.java
@@ -18,7 +18,7 @@ public class GolemMoveToHarvestGoal extends GolemMoveToBreakGoal {
         boolean isCrop = block instanceof CropBlock && ((CropBlock) block).isMature(state);
         boolean isGourd = block instanceof GourdBlock;
         boolean isCane = block instanceof SugarCaneBlock && this.entity.world.getBlockState(pos.down()).getBlock() instanceof SugarCaneBlock;
-        return isCrop || isGourd || isCane;
+        return (isCrop || isGourd || isCane) && super.isTargetPos(pos);
     }
 
     @Override

--- a/src/main/java/net/emirikol/golemancy/entity/goal/GolemMoveToHarvestGoal.java
+++ b/src/main/java/net/emirikol/golemancy/entity/goal/GolemMoveToHarvestGoal.java
@@ -21,7 +21,6 @@ public class GolemMoveToHarvestGoal extends GolemMoveToBreakGoal {
         return (isCrop || isGourd || isCane) && super.isTargetPos(pos);
     }
 
-    @Override
     protected int getMaxProgress() {
         return 40;
     }

--- a/src/main/java/net/emirikol/golemancy/entity/goal/GolemMoveToMineGoal.java
+++ b/src/main/java/net/emirikol/golemancy/entity/goal/GolemMoveToMineGoal.java
@@ -5,9 +5,9 @@ import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.util.math.BlockPos;
 
-public class GolemMoveToBreakBlockGoal extends GolemMoveToBreakGoal {
+public class GolemMoveToMineGoal extends GolemMoveToBreakGoal {
 
-    public GolemMoveToBreakBlockGoal(AbstractGolemEntity entity, float searchRadius, float maxYDifference) {
+    public GolemMoveToMineGoal(AbstractGolemEntity entity, float searchRadius, float maxYDifference) {
         super(entity, searchRadius, maxYDifference);
     }
 

--- a/src/main/java/net/emirikol/golemancy/entity/goal/GolemMoveToPickupGoal.java
+++ b/src/main/java/net/emirikol/golemancy/entity/goal/GolemMoveToPickupGoal.java
@@ -55,6 +55,11 @@ public class GolemMoveToPickupGoal extends GolemMoveGoal {
         return false;
     }
 
+    @Override
+    public double getDesiredDistanceToTarget() {
+        return PICKUP_RANGE;
+    }
+
     public boolean canPickUp(ItemEntity entity) {
         return entity != null;
     }

--- a/src/main/java/net/emirikol/golemancy/entity/goal/GolemMoveToPlantGoal.java
+++ b/src/main/java/net/emirikol/golemancy/entity/goal/GolemMoveToPlantGoal.java
@@ -55,7 +55,7 @@ public class GolemMoveToPlantGoal extends GolemMoveGoal {
         //We can plant seeds on a block if it is farmland and has nothing above it (including existing crops).
         ServerWorld world = (ServerWorld) this.entity.world;
         BlockState state = world.getBlockState(pos);
-        return (state.getBlock() == Blocks.FARMLAND) && world.getBlockState(pos.up()).isAir();
+        return (state.getBlock() == Blocks.FARMLAND) && world.getBlockState(pos.up()).isAir() && super.isTargetPos(pos);
     }
 
     public boolean hasSeed() {

--- a/src/main/java/net/emirikol/golemancy/entity/goal/GolemMoveToSortGoal.java
+++ b/src/main/java/net/emirikol/golemancy/entity/goal/GolemMoveToSortGoal.java
@@ -58,6 +58,11 @@ public class GolemMoveToSortGoal extends GolemMoveGoal {
         return GolemHelper.canInsert(stack, inventory) && this.validForSorting(stack, inventory) && super.isTargetPos(pos);
     }
 
+    @Override
+    public double getDesiredDistanceToTarget() {
+        return DEPOSIT_RANGE;
+    }
+
     public boolean hasSomething() {
         ItemStack stack = this.entity.getEquippedStack(EquipmentSlot.MAINHAND);
         return !stack.isEmpty();

--- a/src/main/java/net/emirikol/golemancy/entity/goal/GolemMoveToSortGoal.java
+++ b/src/main/java/net/emirikol/golemancy/entity/goal/GolemMoveToSortGoal.java
@@ -55,7 +55,7 @@ public class GolemMoveToSortGoal extends GolemMoveGoal {
         BlockPos linkedBlockPos = this.entity.getLinkedBlockPos();
         if (inventory == null || pos.equals(linkedBlockPos) || (linkedBlockPos != null && GolemHelper.sameDoubleInventory(pos, linkedBlockPos, world))) return false;
 
-        return GolemHelper.canInsert(stack, inventory) && this.validForSorting(stack, inventory);
+        return GolemHelper.canInsert(stack, inventory) && this.validForSorting(stack, inventory) && super.isTargetPos(pos);
     }
 
     public boolean hasSomething() {


### PR DESCRIPTION
Implementing a wide variety of improvements to golem AI to address the problems referenced in issue #4. Broadly:

1. Golems now maintain an internal "filter" of BlockPos that they have failed to reach.
2. If a golem idles for more than 2 seconds while trying to perform a movement goal, they give up and add that BlockPos to the filter.
3. If a golem fails to find any target BlockPos at all for the movement goal, they empty out the filter and start over from scratch.
4. When finding a new target BlockPos, they ignore any that are already in the "failed to reach" filter.

This should fix the "golems getting obsessed with stuff they can't reach" bugs by allowing the golems to give up on an unreachable targetPos for now, and try other candidates.